### PR TITLE
Fix thumbnail generation when ImageResizer 4 used

### DIFF
--- a/ImageResizer.Plugins.EPiServerBlobPlugin/EPiServerBlobPlugin.cs
+++ b/ImageResizer.Plugins.EPiServerBlobPlugin/EPiServerBlobPlugin.cs
@@ -52,6 +52,9 @@ namespace ImageResizer.Plugins.EPiServerBlob
 
         private void OnPostAuthorizeRequestStart(IHttpModule sender, HttpContext context)
         {
+            if (context.Request.Url.ToString().Contains("Thumbnail?epieditmode"))
+                return;
+                
             string absolutePath = this.CleanEditModePath(context.Request.Url.AbsolutePath);
             IContent resolvedContent = __urlResolver.Route(new UrlBuilder(absolutePath));
 


### PR DESCRIPTION
Fix problem described in http://world.episerver.com/forum/developer-forum/-EPiServer-75-CMS/Thread-Container/2016/1/thumbnails-in-assets-pane-are-really-full-size-images/
